### PR TITLE
Code signing fixes

### DIFF
--- a/_3rdPartyCodeSign.sh
+++ b/_3rdPartyCodeSign.sh
@@ -28,6 +28,14 @@ function _resign_mach_o_file()
     local path="${1}"
     local entitlements="${2}"
 
+	# Don't freak out if the file doesn't exist ... just return quietly.
+	# Maybe the framework didn't end up bundling every binary the host app thought
+	# it would...
+	if [[ ! -f "${path}" ]]; then
+		echo "Couldn't find existing file for re-signing at path: ${path}"
+		return 0
+	fi
+
     local workspace=$(pwd)
     local tmp="/tmp/$RANDOM"
     local tmp_entitlement="/tmp/$RANDOM"


### PR DESCRIPTION
I was running into annoying build log pseudo-errors when building iMediaTester because my version of iMedia doesn't include stuff like PhFacebook or ObjectiveFlickr.
