### PR TITLE
Don't remove the file name extension when asking NSFileManager for the b...

### DIFF
--- a/IMBFolderParser.m
+++ b/IMBFolderParser.m
@@ -124,7 +124,7 @@
     
 	// Create an empty root node (unpopulated and without subnodes)...
 	
-	NSString* name = [fileManager displayNameAtPath:[path stringByDeletingPathExtension]];
+	NSString* name = [fileManager displayNameAtPath:path];
     name = [name stringByReplacingOccurrencesOfString:@"_" withString:@" "];
 	
 	IMBNode* node = [[[IMBNode alloc] initWithParser: self topLevel:YES] autorelease];


### PR DESCRIPTION
...est display name for an item. This has the unwanted effect of referring to a non-existant path and thus robbing it of its ability to apply any smarts such that e.g. a folder that could be mistaken for having a file extension does not have its name truncated unexpectedly. For example, this fixes a bug in which a folder called "10.10.2 Screenshots" would be displayed by iMedia as "10.10", the "2 Screenshots" having been dutifully removed before asking NSFileManager for a suitable display name.