### PR TITLE
Add build-time conditionals to facilitate building with later deployment target

### DIFF
--- a/IMBAppleMediaLibraryParser.m
+++ b/IMBAppleMediaLibraryParser.m
@@ -181,9 +181,9 @@
 #if CREATE_MEDIA_OBJECTS_CONCURRENTLY
         dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
 #if !OS_OBJECT_USE_OBJC
-		// Only required for 10.7 deployment targets and earlier
-		dispatch_release(dispatchGroup);
-		dispatch_release(semaphore);
+	// Only required for 10.7 deployment targets and earlier
+	dispatch_release(dispatchGroup);
+	dispatch_release(semaphore);
 #endif
 #endif
         STOP_MEASURE(2);

--- a/IMBAppleMediaLibraryParser.m
+++ b/IMBAppleMediaLibraryParser.m
@@ -180,8 +180,11 @@
         }
 #if CREATE_MEDIA_OBJECTS_CONCURRENTLY
         dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
-        dispatch_release(dispatchGroup);
-        dispatch_release(semaphore);
+#if !OS_OBJECT_USE_OBJC
+		// Only required for 10.7 deployment targets and earlier
+		dispatch_release(dispatchGroup);
+		dispatch_release(semaphore);
+#endif
 #endif
         STOP_MEASURE(2);
         LOG_MEASURED_TIME(2, @"IMBObjects creation for group %@", parentGroup.name);

--- a/IMBAppleMediaLibraryPropertySynchronizer.m
+++ b/IMBAppleMediaLibraryPropertySynchronizer.m
@@ -100,7 +100,13 @@
             // Value not present yet, will be provided asynchronously through KVO. Wait for it.
             dispatch_semaphore_wait(instance.semaphore, DISPATCH_TIME_FOREVER);
         }
-        dispatch_release(instance.semaphore);
+
+#if !OS_OBJECT_USE_OBJC
+		// For targets requiring 10.8 or greater we don't need (and in fact can't use) dispatch_release,
+		// because it's handled automatically by ARC.
+		dispatch_release(instance.semaphore);
+#endif
+
         return instance.valueForKey;
     }
     return nil;

--- a/IMBAppleMediaLibraryPropertySynchronizer.m
+++ b/IMBAppleMediaLibraryPropertySynchronizer.m
@@ -102,9 +102,9 @@
         }
 
 #if !OS_OBJECT_USE_OBJC
-		// For targets requiring 10.8 or greater we don't need (and in fact can't use) dispatch_release,
-		// because it's handled automatically by ARC.
-		dispatch_release(instance.semaphore);
+	// For targets requiring 10.8 or greater we don't need (and in fact can't use) dispatch_release,
+	// because it's handled automatically by ARC.
+	dispatch_release(instance.semaphore);
 #endif
 
         return instance.valueForKey;


### PR DESCRIPTION
These changes will preserve functionality of the code when a later SDK/deployment target is adopted. For example in my branch I build for 10.8+ and the dispatch_release calls are causing trouble.