### PR TITLE
I think IMBItemizableView.h and IMBNavigationController.h need to be …

### DIFF
--- a/iMedia.xcodeproj/project.pbxproj
+++ b/iMedia.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		3000AE231618150D00EDC78E /* IMBViewAppearance+iMediaPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3000AE211618150A00EDC78E /* IMBViewAppearance+iMediaPrivate.h */; };
 		3000AE26161816CD00EDC78E /* IMBOutlineView+iMediaPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3000AE25161816CC00EDC78E /* IMBOutlineView+iMediaPrivate.h */; };
 		3000AE2B161A996000EDC78E /* IMBAppleMediaParser+iMediaPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3000AE29161A995F00EDC78E /* IMBAppleMediaParser+iMediaPrivate.h */; };
-		300C8B1A1AF0CEB900F4EC41 /* IMBNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 300C8B181AF0CEB900F4EC41 /* IMBNavigationController.h */; };
+		300C8B1A1AF0CEB900F4EC41 /* IMBNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 300C8B181AF0CEB900F4EC41 /* IMBNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		300C8B1B1AF0CEB900F4EC41 /* IMBNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 300C8B191AF0CEB900F4EC41 /* IMBNavigationController.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3010BE0316A843EC00798D2E /* IMBTestApp.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3010BDF516A843EB00798D2E /* IMBTestApp.xib */; };
 		3010BE0416A843EC00798D2E /* IMBTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3010BDF716A843EC00798D2E /* IMBTestAppDelegate.m */; };
@@ -170,6 +170,7 @@
 		30FD64671546AF6E0036BDE2 /* NSPasteboard+iMedia.m in Sources */ = {isa = PBXBuildFile; fileRef = 30FD64651546AF6E0036BDE2 /* NSPasteboard+iMedia.m */; };
 		30FD646B1546BAE90036BDE2 /* IMBApertureHeaderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FCA064112368388009072AE /* IMBApertureHeaderViewController.m */; };
 		30FFEBFE150A0AA70009C1D0 /* im.edia.iPhoto.xpc in Copy XPCServices */ = {isa = PBXBuildFile; fileRef = 30FFEBEC150A08DB0009C1D0 /* im.edia.iPhoto.xpc */; };
+		6523FF231B0CE589004FD6D2 /* IMBItemizableView.h in Headers */ = {isa = PBXBuildFile; fileRef = 30BC5C641AFF22BE002BF87F /* IMBItemizableView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 		8F47B39110C416050013ED25 /* IMBOrderedDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F47B38F10C416050013ED25 /* IMBOrderedDictionary.h */; };
 		8F47B39210C416050013ED25 /* IMBOrderedDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F47B39010C416050013ED25 /* IMBOrderedDictionary.m */; };
@@ -2413,6 +2414,7 @@
 				303FFD6A152CBC3B0026B8CF /* IMBSkimmableObject.h in Headers */,
 				3000AE1F1617AE2200EDC78E /* IMBViewAppearance.h in Headers */,
 				303FFD76152CBD000026B8CF /* IMBFaceNodeObject.h in Headers */,
+				6523FF231B0CE589004FD6D2 /* IMBItemizableView.h in Headers */,
 				D0904DF6152D7478003FDD08 /* IMBSafariParserMessenger.h in Headers */,
 				D0904E07152D936C003FDD08 /* IMBLinkObject.h in Headers */,
 				D0904E2A152DB2BE003FDD08 /* IMBLightroom4Parser.h in Headers */,


### PR DESCRIPTION
…public headers because they are imported by public headers? A little confused, but making these public fixes my MarsEdit build, which was failing trying to import iMedia/iMedia.h. I wonder if iMedia's iMediaTester target should actually live in a separate project so that it doesn't benefit from header import rules that work because it is in the same project as iMedia itself? This would reveal build errors like this sooner.
