### PR TITLE
Fix top level node loading

### DIFF
--- a/IMBLibraryController.m
+++ b/IMBLibraryController.m
@@ -824,11 +824,18 @@ static NSMutableDictionary* sLibraryControllers = nil;
 	if (inOldNode == nil && inNewNode == nil) return;
 	
 	// Log an error if we are supposed to remove an old node, but it already removed from the tree...
-	
+
 	if (inOldNode != nil && inOldNode.parentNode == nil)
 	{
-		NSLog(@"%s inOldNode has already been removed. This was problably a race condition...",__FUNCTION__);
-		return;
+		// It's possible (in some contrived situations e.g. if a client app uses a very customized iMedia view),
+		// for a node to be both a top level node, not have a group node parent, and to contain media objects. In
+		// this case we want to avoid bailing out when the node doesn't have a parent, because it never will
+		// have one.
+		if ([inOldNode isTopLevelNode] == NO)
+		{
+			NSLog(@"%s inOldNode has already been removed. This was problably a race condition...",__FUNCTION__);
+			return;
+		}
 	}
 	
 	if (inOldNode != nil && inOldNode.parentNode == nil)

--- a/IMBLibraryController.m
+++ b/IMBLibraryController.m
@@ -824,11 +824,17 @@ static NSMutableDictionary* sLibraryControllers = nil;
 	if (inOldNode == nil && inNewNode == nil) return;
 	
 	// Log an error if we are supposed to remove an old node, but it already removed from the tree...
-	
+
 	if (inOldNode != nil && inOldNode.parentNode == nil)
 	{
-		NSLog(@"%s inOldNode has already been removed. This was problably a race condition...",__FUNCTION__);
-		return;
+		// It's possible (in some contrived situations e.g. if a client app uses a very customized iMedia view),
+		// for a node to be both a top level node and contain media objects. In this case we want to avoid bailing
+		// out when the node doesn't have a parent, because it never will have a parent, but we still want to reload it.
+		if ([inOldNode isTopLevelNode] == NO)
+		{
+			NSLog(@"%s inOldNode has already been removed. This was problably a race condition...",__FUNCTION__);
+			return;
+		}
 	}
 	
 	if (inOldNode != nil && inOldNode.parentNode == nil)


### PR DESCRIPTION
Ensure that a top level node that happens to also not have a parent will still be reloaded. This seems contrived but I run into this in MarsEdit, where I use a customized IMBLIbraryController that possesses only one node with images, for some specialized media views.
