### PR TITLE
Alleviate clang analysis nil-parameter warnings

### DIFF
--- a/IMBNodeViewController.m
+++ b/IMBNodeViewController.m
@@ -1458,7 +1458,7 @@ static NSMutableDictionary* sRegisteredNodeViewControllerClasses = nil;
 			selectedNodeIdentifier = identifier;
 		}
 	
-		if ([identifier isEqualToString:selectedNodeIdentifier])
+		if (selectedNodeIdentifier && [identifier isEqualToString:selectedNodeIdentifier])
 		{
 			[self selectNode:node];
 			found = YES;

--- a/IMBObject.m
+++ b/IMBObject.m
@@ -400,7 +400,11 @@ NSString* kIMBObjectPasteboardType = @"com.karelia.imedia.IMBObject";
 	}
 	else if ([[self URL] isFileURL])
 	{
-		icon = [[NSWorkspace imb_threadSafeWorkspace] iconForFileType:self.type];
+		NSString* iconType = self.type;
+		if (iconType != nil)
+		{
+			icon = [[NSWorkspace imb_threadSafeWorkspace] iconForFileType:iconType];
+		}
 	}
 	
 	return icon;

--- a/IMBParser.m
+++ b/IMBParser.m
@@ -428,7 +428,7 @@
 
 	// Render the thumbnail...
 	
-	if (error == nil)
+	if ((error == nil) && (source != nil))
 	{
 		if (shouldScaleDown)
 		{

--- a/IMBSafariParser.m
+++ b/IMBSafariParser.m
@@ -197,7 +197,8 @@
 	
 	@synchronized(self)
 	{
-		if ([self.modificationDate compare:modificationDate] == NSOrderedAscending)
+		// If for some reason the modification date could not be fetched, or the modification is newer, recache
+		if ((modificationDate == nil) || ([self.modificationDate compare:modificationDate] == NSOrderedAscending))
 		{
 			self.plist = nil;
 		}

--- a/IMBiTunesAudioParser.m
+++ b/IMBiTunesAudioParser.m
@@ -254,7 +254,8 @@
 	
 	@synchronized(self)
 	{
-		if ([self.modificationDate compare:modificationDate] == NSOrderedAscending)
+		// If for some reason the modification date could not be fetched, or the modification is newer, recache
+		if ((modificationDate == nil) || ([self.modificationDate compare:modificationDate] == NSOrderedAscending))
 		{
 			self.atomic_plist = nil;
 		}

--- a/NSString+iMedia.m
+++ b/NSString+iMedia.m
@@ -379,7 +379,14 @@
 	[formatter setDateStyle:NSDateFormatterMediumStyle];    // medium date
 	[formatter setTimeStyle:NSDateFormatterShortStyle];     // no seconds
 
-	NSString *result = [formatter stringFromDate:date];
+	// date should never be nil but clang analyis detects a possibility of
+	// nil date if [timeInterval integerValue] above is 0. Let's cover the
+	// case explicitly to quiet clang analysis.
+	NSString* result = nil;
+	if (date != nil)
+	{
+		result = [formatter stringFromDate:date];
+	}
 
 	[formatter release];
 	[parser release];


### PR DESCRIPTION
These warnings came up with clang analayis on Xcode 7.3 (may have been present earlier). I think formalizing the expectations in our code is a good idea. In particular some cases where undefined behavior would have been met are now at least reasoned in the handling of nil values.
