### PR TITLE
Fixes to Lightroom video parsers

### DIFF
--- a/IMBLightroom3VideoParser.m
+++ b/IMBLightroom3VideoParser.m
@@ -97,5 +97,21 @@
 
 //----------------------------------------------------------------------------------------------------------------------
 
++ (NSString*) identifier
+{
+	return @"com.karelia.imedia.Lightroom3.movie";
+}
+
+// This method must return an appropriate prefix for IMBObject identifiers. Refer to the method
+// -[IMBParser iMedia2PersistentResourceIdentifierForObject:] to see how it is used. Historically we used class names as the prefix.
+// However, during the evolution of iMedia class names can change and identifier string would thus also change.
+// This is undesirable, as things that depend of the immutability of identifier strings would break. One such
+// example are the object badges, which use object identifiers. To guarrantee backward compatibilty, a parser
+// class must override this method to return a prefix that matches the historic class name...
+
+- (NSString*) iMedia2PersistentResourceIdentifierPrefix
+{
+	return @"IMBLightroom3VideoParser";
+}
 
 @end

--- a/IMBLightroom4VideoParser.m
+++ b/IMBLightroom4VideoParser.m
@@ -96,5 +96,21 @@
 
 //----------------------------------------------------------------------------------------------------------------------
 
++ (NSString*) identifier
+{
+	return @"com.karelia.imedia.Lightroom4.movie";
+}
+
+// This method must return an appropriate prefix for IMBObject identifiers. Refer to the method
+// -[IMBParser iMedia2PersistentResourceIdentifierForObject:] to see how it is used. Historically we used class names as the prefix.
+// However, during the evolution of iMedia class names can change and identifier string would thus also change.
+// This is undesirable, as things that depend of the immutability of identifier strings would break. One such
+// example are the object badges, which use object identifiers. To guarrantee backward compatibilty, a parser
+// class must override this method to return a prefix that matches the historic class name...
+
+- (NSString*) iMedia2PersistentResourceIdentifierPrefix
+{
+	return @"IMBLightroom4VideoParser";
+}
 
 @end

--- a/IMBLightroom5Parser.m
+++ b/IMBLightroom5Parser.m
@@ -243,15 +243,15 @@
 			pyramidPath = [self pyramidPathForImage:idLocal];
 		}
 
-		if ([self canOpenImageFileAtPath:path]) {
+		if ([self canOpenFileAtPath:path]) {
 			NSMutableDictionary *metadata	= [NSMutableDictionary dictionary];
 
-			[metadata setObject:path forKey:@"MasterPath"];
-			[metadata setObject:idLocal forKey:@"idLocal"];
-			[metadata setObject:path forKey:@"path"];
-			[metadata setObject:fileHeight forKey:@"height"];
-			[metadata setObject:fileWidth forKey:@"width"];
-			[metadata setObject:orientation forKey:@"orientation"];
+			[metadata setValue:path forKey:@"MasterPath"];
+			[metadata setValue:idLocal forKey:@"idLocal"];
+			[metadata setValue:path forKey:@"path"];
+			[metadata setValue:fileHeight forKey:@"height"];
+			[metadata setValue:fileWidth forKey:@"width"];
+			[metadata setValue:orientation forKey:@"orientation"];
 
 			if (name) {
 				[metadata setObject:name forKey:@"name"];

--- a/IMBLightroom5VideoParser.m
+++ b/IMBLightroom5VideoParser.m
@@ -97,5 +97,21 @@
 
 //----------------------------------------------------------------------------------------------------------------------
 
++ (NSString*) identifier
+{
+	return @"com.karelia.imedia.Lightroom5.movie";
+}
+
+// This method must return an appropriate prefix for IMBObject identifiers. Refer to the method
+// -[IMBParser iMedia2PersistentResourceIdentifierForObject:] to see how it is used. Historically we used class names as the prefix.
+// However, during the evolution of iMedia class names can change and identifier string would thus also change.
+// This is undesirable, as things that depend of the immutability of identifier strings would break. One such
+// example are the object badges, which use object identifiers. To guarrantee backward compatibilty, a parser
+// class must override this method to return a prefix that matches the historic class name...
+
+- (NSString*) iMedia2PersistentResourceIdentifierPrefix
+{
+	return @"IMBLightroom5VideoParser";
+}
 
 @end

--- a/IMBLightroom6Parser.m
+++ b/IMBLightroom6Parser.m
@@ -243,15 +243,15 @@
 			pyramidPath = [self pyramidPathForImage:idLocal];
 		}
 
-		if ([self canOpenImageFileAtPath:path]) {
+		if ([self canOpenFileAtPath:path]) {
 			NSMutableDictionary *metadata	= [NSMutableDictionary dictionary];
 
-			[metadata setObject:path forKey:@"MasterPath"];
-			[metadata setObject:idLocal forKey:@"idLocal"];
-			[metadata setObject:path forKey:@"path"];
-			[metadata setObject:fileHeight forKey:@"height"];
-			[metadata setObject:fileWidth forKey:@"width"];
-			[metadata setObject:orientation forKey:@"orientation"];
+			[metadata setValue:path forKey:@"MasterPath"];
+			[metadata setValue:idLocal forKey:@"idLocal"];
+			[metadata setValue:path forKey:@"path"];
+			[metadata setValue:fileHeight forKey:@"height"];
+			[metadata setValue:fileWidth forKey:@"width"];
+			[metadata setValue:orientation forKey:@"orientation"];
 
 			if (name) {
 				[metadata setObject:name forKey:@"name"];
@@ -664,7 +664,7 @@
 
 - (NSString *)iMedia2PersistentResourceIdentifierPrefix
 {
-	return @"IMBLightroomgParser";
+	return @"IMBLightroom6Parser";
 }
 
 @end

--- a/IMBLightroom6VideoParser.m
+++ b/IMBLightroom6VideoParser.m
@@ -97,5 +97,21 @@
 
 //----------------------------------------------------------------------------------------------------------------------
 
++ (NSString*) identifier
+{
+	return @"com.karelia.imedia.Lightroom6.movie";
+}
+
+// This method must return an appropriate prefix for IMBObject identifiers. Refer to the method
+// -[IMBParser iMedia2PersistentResourceIdentifierForObject:] to see how it is used. Historically we used class names as the prefix.
+// However, during the evolution of iMedia class names can change and identifier string would thus also change.
+// This is undesirable, as things that depend of the immutability of identifier strings would break. One such
+// example are the object badges, which use object identifiers. To guarrantee backward compatibilty, a parser
+// class must override this method to return a prefix that matches the historic class name...
+
+- (NSString*) iMedia2PersistentResourceIdentifierPrefix
+{
+	return @"IMBLightroom6VideoParser";
+}
 
 @end

--- a/IMBLightroomParser.h
+++ b/IMBLightroomParser.h
@@ -181,7 +181,7 @@ IMBLightroomNodeType;
 + (NSImage*) largeFolderIcon;
 
 - (NSNumber*) idLocalFromAttributes:(NSDictionary*)inAttributes;
-- (BOOL) canOpenImageFileAtPath:(NSString*)inPath;
+- (BOOL) canOpenFileAtPath:(NSString*)inPath;
 - (IMBObject*) objectWithPath:(NSString*)inPath
 					  idLocal:(NSNumber*)idLocal
 						 name:(NSString*)inName

--- a/IMBLightroomParser.m
+++ b/IMBLightroomParser.m
@@ -81,7 +81,7 @@
 
 #pragma mark GLOBALS
 
-static NSArray* sSupportedUTIs = nil;
+static NSArray* sSupportedImageUTIs = nil;
 
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ static NSArray* sSupportedUTIs = nil;
 - (NSString*) libraryName;
 
 - (NSArray*) supportedUTIs;
-- (BOOL) canOpenImageFileAtPath:(NSString*)inPath;
+- (BOOL) canOpenFileAtPath:(NSString*)inPath;
 - (IMBObject*) objectWithPath:(NSString*)inPath
 					  idLocal:(NSNumber*)idLocal
 						 name:(NSString*)inName
@@ -183,7 +183,7 @@ static NSArray* sSupportedUTIs = nil;
 		_databases = [[NSMutableDictionary alloc] init];
 		_thumbnailDatabases = [[NSMutableDictionary alloc] init];		
 		
-		[self supportedUTIs];	// Init early and in the main thread!
+		[self supportedImageUTIs];	// Init early and in the main thread!
 	}
 	
 	return self;
@@ -1019,15 +1019,15 @@ static NSArray* sSupportedUTIs = nil;
 				pyramidPath = [self pyramidPathForImage:idLocal];
 			}
 			
-			if ([self canOpenImageFileAtPath:path]) {
+			if ([self canOpenFileAtPath:path]) {
 				NSMutableDictionary* metadata = [NSMutableDictionary dictionary];
 				
-				[metadata setObject:path forKey:@"MasterPath"];
-				[metadata setObject:idLocal forKey:@"idLocal"];
-				[metadata setObject:path forKey:@"path"];
-				[metadata setObject:fileHeight forKey:@"height"];
-				[metadata setObject:fileWidth forKey:@"width"];
-				[metadata setObject:orientation forKey:@"orientation"];
+				[metadata setValue:path forKey:@"MasterPath"];
+				[metadata setValue:idLocal forKey:@"idLocal"];
+				[metadata setValue:path forKey:@"path"];
+				[metadata setValue:fileHeight forKey:@"height"];
+				[metadata setValue:fileWidth forKey:@"width"];
+				[metadata setValue:orientation forKey:@"orientation"];
 				
 				if (name) {
 					[metadata setObject:name forKey:@"name"];
@@ -1102,16 +1102,16 @@ static NSArray* sSupportedUTIs = nil;
 				pyramidPath = [self pyramidPathForImage:idLocal];
 			}
 			
-			if ([self canOpenImageFileAtPath:path]) {
+			if ([self canOpenFileAtPath:path]) {
 				NSMutableDictionary* metadata = [NSMutableDictionary dictionary];
 				
-				[metadata setObject:path forKey:@"MasterPath"];
-				[metadata setObject:idLocal forKey:@"idLocal"];
-				[metadata setObject:path forKey:@"path"];
-				[metadata setObject:fileHeight forKey:@"height"];
-				[metadata setObject:fileWidth forKey:@"width"];
-				[metadata setObject:orientation forKey:@"orientation"];
-				
+				[metadata setValue:path forKey:@"MasterPath"];
+				[metadata setValue:idLocal forKey:@"idLocal"];
+				[metadata setValue:path forKey:@"path"];
+				[metadata setValue:fileHeight forKey:@"height"];
+				[metadata setValue:fileWidth forKey:@"width"];
+				[metadata setValue:orientation forKey:@"orientation"];
+
 				if (name) {
 					[metadata setObject:name forKey:@"name"];
 				}
@@ -1153,7 +1153,7 @@ static NSArray* sSupportedUTIs = nil;
 
 // Check if we can open this image file...
 
-- (BOOL) canOpenImageFileAtPath:(NSString*)inPath
+- (BOOL) canOpenFileAtPath:(NSString*)inPath
 {
 	NSString* uti = [NSString imb_UTIForFileAtPath:inPath];
 	NSArray* supportedUTIs = [self supportedUTIs];
@@ -1171,14 +1171,38 @@ static NSArray* sSupportedUTIs = nil;
 
 - (NSArray*) supportedUTIs
 {
-	if (sSupportedUTIs == nil)
-	{
-		sSupportedUTIs = (NSArray*) CGImageSourceCopyTypeIdentifiers();
-	}	
-	
-	return sSupportedUTIs;
+	static NSMutableDictionary *supportedUTIsByMediaType;
+	static dispatch_once_t onceToken;
+
+	dispatch_once(&onceToken, ^{
+		NSArray *supportedImageUTIs = [self supportedImageUTIs];
+
+		if (supportedImageUTIs == nil) {
+			supportedImageUTIs = [NSArray arrayWithObjects:(NSString*)kUTTypeImage, nil];
+		}
+
+		supportedUTIsByMediaType = [[NSMutableDictionary alloc] init];
+
+		[supportedUTIsByMediaType setObject:supportedImageUTIs
+									 forKey:kIMBMediaTypeImage];
+		[supportedUTIsByMediaType setObject:[NSArray arrayWithObjects:(NSString*)kUTTypeMovie, nil]
+									 forKey:kIMBMediaTypeMovie];
+		[supportedUTIsByMediaType setObject:[NSArray arrayWithObjects:(NSString*)kUTTypeAudio, nil]
+									 forKey:kIMBMediaTypeAudio];
+	});
+
+	return [supportedUTIsByMediaType objectForKey:self.mediaType];
 }
 
+- (NSArray*) supportedImageUTIs
+{
+	if (sSupportedImageUTIs == nil)
+	{
+		sSupportedImageUTIs = (NSArray*) CGImageSourceCopyTypeIdentifiers();
+	}
+
+	return sSupportedImageUTIs;
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/IMBLightroomParserMessenger.h
+++ b/IMBLightroomParserMessenger.h
@@ -71,7 +71,7 @@
 @end
 
 
-@interface IMBLightroomsMovieParserMessenger : IMBLightroomParserMessenger
+@interface IMBLightroomMovieParserMessenger : IMBLightroomParserMessenger
 
 @end
 

--- a/IMBLightroomParserMessenger.m
+++ b/IMBLightroomParserMessenger.m
@@ -70,14 +70,7 @@
 #import "NSFileManager+iMedia.h"
 #import "NSDictionary+iMedia.h"
 #import "NSImage+iMedia.h"
-
-
-//----------------------------------------------------------------------------------------------------------------------
-
-
-#pragma mark GLOBALS
-
-static dispatch_once_t sOnceToken = 0;
+#import "NSObject+iMedia.h"
 
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -89,21 +82,6 @@ static dispatch_once_t sOnceToken = 0;
 
 
 //----------------------------------------------------------------------------------------------------------------------
-
-
-// Returns the list of parsers this messenger instantiated
-
-+ (NSMutableArray *)parsers
-{
-    static NSMutableArray *parsers = nil;
-    
-    static dispatch_once_t onceToken = 0;
-    dispatch_once(&onceToken, ^{
-        parsers = [[NSMutableArray alloc] init];
-    });
-    return parsers;
-}
-
 
 - (id) init
 {
@@ -159,31 +137,6 @@ static dispatch_once_t sOnceToken = 0;
 
 + (NSString*) identifier
 {
-	if ([IMBLightroom6Parser lightroomPath])
-	{
-		return [IMBLightroom6Parser identifier];
-	}
-	else if ([IMBLightroom5Parser lightroomPath])
-	{
-		return [IMBLightroom5Parser identifier];
-	}
-	else if ([IMBLightroom4Parser lightroomPath])
-	{
-		return [IMBLightroom4Parser identifier];
-	}
-	else if ([IMBLightroom3Parser lightroomPath])
-	{
-		return [IMBLightroom3Parser identifier];
-	}
-	else if ([IMBLightroom2Parser lightroomPath])
-	{
-		return [IMBLightroom2Parser identifier];
-	}
-	else if ([IMBLightroom1Parser lightroomPath])
-	{
-		return [IMBLightroom1Parser identifier];
-	}
-	
 	return nil;
 }
 
@@ -207,9 +160,9 @@ static dispatch_once_t sOnceToken = 0;
 
 - (NSArray*) parserInstancesWithError:(NSError**)outError
 {
-    Class messengerClass = [self class];
-    NSMutableArray *parsers = [messengerClass parsers];
-    dispatch_once(&sOnceToken,
+	Class messengerClass = [self class];
+	NSMutableArray *parsers = [messengerClass parsers];
+	dispatch_once([messengerClass onceTokenRef],
     ^{
 		if ([[self class] isInstalled])
 		{
@@ -256,6 +209,31 @@ static dispatch_once_t sOnceToken = 0;
 }
 
 
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the list of parsers this messenger instantiated
+
++ (NSMutableArray *)parsers
+{
+	static NSMutableArray *parsers = nil;
+
+	static dispatch_once_t onceToken = 0;
+	dispatch_once(&onceToken, ^{
+		parsers = [[NSMutableArray alloc] init];
+	});
+	return parsers;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the dispatch-once token
+
++ (dispatch_once_t *)onceTokenRef
+{
+	static dispatch_once_t onceToken = 0;
+
+	return &onceToken;
+}
+
 @end
 
 
@@ -271,6 +249,36 @@ static dispatch_once_t sOnceToken = 0;
 + (NSString*) mediaType
 {
 	return kIMBMediaTypeImage;
+}
+
++ (NSString*) identifier
+{
+	if ([IMBLightroom6Parser lightroomPath])
+	{
+		return [IMBLightroom6Parser identifier];
+	}
+	else if ([IMBLightroom5Parser lightroomPath])
+	{
+		return [IMBLightroom5Parser identifier];
+	}
+	else if ([IMBLightroom4Parser lightroomPath])
+	{
+		return [IMBLightroom4Parser identifier];
+	}
+	else if ([IMBLightroom3Parser lightroomPath])
+	{
+		return [IMBLightroom3Parser identifier];
+	}
+	else if ([IMBLightroom2Parser lightroomPath])
+	{
+		return [IMBLightroom2Parser identifier];
+	}
+	else if ([IMBLightroom1Parser lightroomPath])
+	{
+		return [IMBLightroom1Parser identifier];
+	}
+
+	return nil;
 }
 
 + (NSString*) parserClassName
@@ -310,6 +318,31 @@ static dispatch_once_t sOnceToken = 0;
 	[pool drain];
 }
 
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the list of parsers this messenger instantiated
+
++ (NSMutableArray *)parsers
+{
+	static NSMutableArray *parsers = nil;
+
+	static dispatch_once_t onceToken = 0;
+	dispatch_once(&onceToken, ^{
+		parsers = [[NSMutableArray alloc] init];
+	});
+	return parsers;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the dispatch-once token
+
++ (dispatch_once_t *)onceTokenRef
+{
+	static dispatch_once_t onceToken = 0;
+
+	return &onceToken;
+}
+
 @end
 
 
@@ -320,11 +353,33 @@ static dispatch_once_t sOnceToken = 0;
 
 // Specify parameters for movie subclass and register it...
  
-@implementation IMBLightroomsMovieParserMessenger
+@implementation IMBLightroomMovieParserMessenger
 
 + (NSString*) mediaType
 {
 	return kIMBMediaTypeMovie;
+}
+
++ (NSString*) identifier
+{
+	if ([IMBLightroom6VideoParser lightroomPath])
+	{
+		return [IMBLightroom6VideoParser identifier];
+	}
+	else if ([IMBLightroom5VideoParser lightroomPath])
+	{
+		return [IMBLightroom5VideoParser identifier];
+	}
+	else if ([IMBLightroom4VideoParser lightroomPath])
+	{
+		return [IMBLightroom4Parser identifier];
+	}
+	else if ([IMBLightroom3VideoParser lightroomPath])
+	{
+		return [IMBLightroom3VideoParser identifier];
+	}
+
+	return nil;
 }
 
 + (NSString*) parserClassName
@@ -354,6 +409,31 @@ static dispatch_once_t sOnceToken = 0;
 	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 	[IMBParserController registerParserMessengerClass:self forMediaType:[self mediaType]];
 	[pool drain];
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the list of parsers this messenger instantiated
+
++ (NSMutableArray *)parsers
+{
+	static NSMutableArray *parsers = nil;
+
+	static dispatch_once_t onceToken = 0;
+	dispatch_once(&onceToken, ^{
+		parsers = [[NSMutableArray alloc] init];
+	});
+	return parsers;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Returns the dispatch-once token
+
++ (dispatch_once_t *)onceTokenRef
+{
+	static dispatch_once_t onceToken = 0;
+
+	return &onceToken;
 }
 
 @end


### PR DESCRIPTION
- Image and video parsers shared the same identifiers
- parserInstancesWithError: created parsers only for the first media type it was called with
- canOpenImageFileAtPath: was called by video parsers, but let only images through
