### PR TITLE
Fix for #83: Node tree badges draw too close to edge of view

### DIFF
--- a/IMBNodeCell.m
+++ b/IMBNodeCell.m
@@ -222,7 +222,7 @@
 - (NSRect) badgeRectForBounds:(NSRect)inBounds flipped:(BOOL)inFlipped
 {	
 	NSRect badgeRect = inBounds;
-	badgeRect.origin.x = NSMaxX(inBounds) - kIconImageSize + kImageOriginXOffset;
+	badgeRect.origin.x = NSMaxX(inBounds) - kIconImageSize - kImageOriginXOffset;
 	badgeRect.origin.y -= kImageOriginYOffset;
 	badgeRect.size = NSMakeSize(kIconImageSize,kIconImageSize);
 

--- a/IMBOutlineView.m
+++ b/IMBOutlineView.m
@@ -176,7 +176,19 @@
 - (NSRect) badgeRectForRow:(NSInteger)inRow
 {
 	IMBNodeCell* cell = (IMBNodeCell*)[self preparedCellAtColumn:0 row:inRow];
-	NSRect bounds = NSInsetRect([self rectOfRow:inRow],9.0,0.0);
+
+	// To correctly place the badge rect, we need to account for the table's intercellSpacing.
+	// This can be done either by taking the whole rect of the row and subtracting the pertinent
+	// spacing, but in this case we would still have to be assuming there is only one column
+	// in order to be confident that the rect is on the right edge of the appropriate column.
+	// It doesn't really matter which of these options we take but either one relies on the
+	// assumption that we haven't added an additional column:
+
+	NSAssert([self numberOfColumns] == 1, @"We must reconsider placement of the badge rect in the row, because we've added an additional column to the outline view.");
+
+//	NSRect bounds = NSInsetRect([self rectOfRow:inRow],[self intercellSpacing].width / 2.0,0.0);
+	NSRect bounds = [self frameOfCellAtColumn:0 row:inRow];
+
 	return [cell badgeRectForBounds:bounds flipped:YES];
 }
 


### PR DESCRIPTION
Fix the arithmetic in -[IMBNodeCell badgeRectForBounds] so that it appropriately offsets the badge position leftward to accommodate the kImageOriginXOffset, pulling it away from the edge of the view. Clean up the behavior of -[IMBOutlineView badgeRectForRow:] so that it no longer hardcodes the inset relative to the row rect, but instead uses the -frameOfCellAtColumn: method so that any intercellSpacing is automatically considered.

With this commit the badges are now drawn appropriately offset from the right edge of the view, and the progress indicators are aligned perfectly with them.
