### PR TITLE
Discard security scoped bookmarks that no longer resolve successfully

### DIFF
--- a/IMBAccessRightsController.m
+++ b/IMBAccessRightsController.m
@@ -208,23 +208,43 @@ static NSString* kBookmarksPrefsKey = @"accessRightsBookmarks";
 {
 	NSArray* bookmarks = [IMBConfig prefsValueForKey:kBookmarksPrefsKey];
 	self.bookmarks = [NSMutableArray arrayWithArray:bookmarks];
-    
+
+	// If url is nil for any reason, we have to assume that the bookmark is not valuable to us,
+	// e.g. because there was an error decoding it. This appears to be possible for example if
+	// we have some bookmarks around that are no longer satisfactorily protected (?) by security
+	// scoping. I ran into some bookmarks that fail to resolve with security scope, but because they
+	// are held in the list of bookmarks, the app continually assumes it already has security access,
+	// and thus renewed security authorization is not bothered to be persisted.
+	NSMutableArray* bookmarksToRemove = [NSMutableArray array];
+
 	for (NSData* bookmark in self.bookmarks)
 	{
 		NSURL* url = [[self class] _urlForAppScopedBookmark:bookmark];
-        
-        // NOTE: We do not balance -startAccessing... with a corresponding -stopAccessing somewhere else
-        //       since we want to be able to access the resource throughout the lifetime of the process
-        //       (and there is no -applicationWillTerminate equivalent hook for XPC services).
-        //       This should not matter since Apple documentation says that associated kernel resources
-        //       will be reclaimed when the process ends.
-        
-        if ([url respondsToSelector:@selector(startAccessingSecurityScopedResource)])   // True for 10.7.3 and later
-        {
-            [url startAccessingSecurityScopedResource];
-        }
-        
-//        NSLog(@"Entitlements: Loaded from preferences security scoped URL %@", url);
+
+		if (url == nil)
+		{
+			[bookmarksToRemove addObject:bookmark];
+		}
+		else
+		{
+			// NOTE: We do not balance -startAccessing... with a corresponding -stopAccessing somewhere else
+			//       since we want to be able to access the resource throughout the lifetime of the process
+			//       (and there is no -applicationWillTerminate equivalent hook for XPC services).
+			//       This should not matter since Apple documentation says that associated kernel resources
+			//       will be reclaimed when the process ends.
+
+			if ([url respondsToSelector:@selector(startAccessingSecurityScopedResource)])   // True for 10.7.3 and later
+			{
+				[url startAccessingSecurityScopedResource];
+			}
+
+			//        NSLog(@"Entitlements: Loaded from preferences security scoped URL %@", url);
+		}
+	}
+
+	for (NSData* bookmark in bookmarksToRemove)
+	{
+		[self.bookmarks removeObject:bookmark];
 	}
 }
 


### PR DESCRIPTION
An issue exists when a saved bookmark, for whatever reason, cannot be resolved to a secure URL. Because it cannot convey security privileges to the pertinent URL, it forces a re-authorization panel from the user. But because it remains held in the bookmarks array, it is assumed valid when consulted by -hasBookmarkForURL: and thus causes the newly created bookmark not to be saved to the bookmarks list.

I'm not sure what the variety of issues are that could cause the bookmark resolution to fail, but I suspect at least one of them was changing the bundle identifier for my host app. I think this caused all of my existing bookmarks to become invalid. Even though they possess the information about the URL in question, they no longer warrant the authority to access the resource. This is one example but there are surely others, so responding in some way to failure of bookmarks to resolve seems like a good call.

The user-facing consequence of this situation is that access to an affected resource has to be granted every single time the app is run.

I'm not sure this is the 100% right solution, but it seems preferable to the status quo: if when loading bookmarks from prefs, if a bookmark fails to resolve with security scope, then remove it from the list of bookmarks. This will force a new authorization from the user which will successfully replace the old version.
