### PR TITLE
Avoid comparing a BOOL to YES, because Objective-C does not guarantee…

### DIFF
--- a/IMBLibraryController.m
+++ b/IMBLibraryController.m
@@ -763,7 +763,7 @@ static NSMutableDictionary* sLibraryControllers = nil;
 	
 	for (IMBNode* node in _subnodes)
 	{
-		if (node.groupType == groupType && node.isGroupNode == YES)
+		if ((node.groupType == groupType) && node.isGroupNode)
 		{
 			return node;
 		}


### PR DESCRIPTION
… that a true BOOL value will be 1 (YES).
