### PR TITLE
Defer Lightroom database version check

### DIFF
--- a/IMBLightroom2Parser.m
+++ b/IMBLightroom2Parser.m
@@ -126,7 +126,7 @@
 // This method creates the immediate subnodes of the "Lightroom" root node. The two subnodes are "Folders"  
 // and "Collections"...
 
-- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode
+- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode error:(NSError**)outError
 {
 	NSMutableArray* subnodes = [inRootNode mutableArrayForPopulatingSubnodes];
 	NSMutableArray* objects = [NSMutableArray array];
@@ -171,7 +171,7 @@
 	
 	// Add the Collections node...
 	
-	[super populateSubnodesForRootNode:inRootNode];
+	[super populateSubnodesForRootNode:inRootNode error:outError];
 }
 
 

--- a/IMBLightroom3Parser.m
+++ b/IMBLightroom3Parser.m
@@ -107,6 +107,10 @@
     return @"com.adobe.Lightroom3";
 }
 
++ (NSString *)lightroomAppVersion
+{
+    return @"3";
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -197,9 +201,11 @@
 		else if (databaseVersionLong >= 400000) {
 			return NO;
 		}
+        
+        return YES;
 	}
 	
-	return YES;
+	return NO;
 }
 
 

--- a/IMBLightroom4Parser.m
+++ b/IMBLightroom4Parser.m
@@ -105,6 +105,10 @@
     return @"com.adobe.Lightroom4";
 }
 
++ (NSString *)lightroomAppVersion
+{
+    return @"4";
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -122,9 +126,11 @@
 		else if (databaseVersionLong >= 500000) {
 			return NO;
 		}
+        
+        return YES;
 	}
 	
-	return YES;
+	return NO;
 }
 
 

--- a/IMBLightroom5Parser.m
+++ b/IMBLightroom5Parser.m
@@ -110,6 +110,11 @@
 	return @"com.adobe.Lightroom5";
 }
 
++ (NSString *)lightroomAppVersion
+{
+    return @"5";
+}
+
 // ----------------------------------------------------------------------------------------------------------------------
 
 
@@ -126,9 +131,11 @@
 		else if (databaseVersionLong >= 600000) {
 			return NO;
 		}
+        
+        return YES;
 	}
 
-	return YES;
+	return NO;
 }
 
 #if LOAD_SMART_COLLECTIONS

--- a/IMBLightroom6Parser.m
+++ b/IMBLightroom6Parser.m
@@ -110,8 +110,12 @@
 	return @"com.adobe.Lightroom6";
 }
 
-// ----------------------------------------------------------------------------------------------------------------------
++ (NSString *)lightroomAppVersion
+{
+    return @"6";
+}
 
+// ----------------------------------------------------------------------------------------------------------------------
 
 - (BOOL)checkDatabaseVersion
 {
@@ -126,9 +130,11 @@
 		else if (databaseVersionLong >= 700000) {
 			return NO;
 		}
+        
+        return YES;
 	}
 
-	return YES;
+	return NO;
 }
 
 #if LOAD_SMART_COLLECTIONS

--- a/IMBLightroomModernParser.h
+++ b/IMBLightroomModernParser.h
@@ -61,6 +61,8 @@
 	
 }
 
++ (NSString *)lightroomAppVersion;
+
 - (NSNumber*) databaseVersion;
 
 + (NSData*) previewDataForLightroomObject:(IMBLightroomObject*)lightroomObject maximumSize:(NSNumber*)maximumSize;

--- a/IMBLightroomModernParser.m
+++ b/IMBLightroomModernParser.m
@@ -64,6 +64,7 @@
 #import "NSObject+iMedia.h"
 #import "NSFileManager+iMedia.h"
 #import "NSImage+iMedia.h"
+#import "NSURL+iMedia.h"
 #import "NSWorkspace+iMedia.h"
 #import "SBUtilities.h"
 #import <Quartz/Quartz.h>
@@ -126,21 +127,29 @@
 	if ([self lightroomPath] != nil) {
 		NSArray* libraryPaths = [self libraryPaths];
 		
-		for (NSString* libraryPath in libraryPaths) {
-			IMBLightroomModernParser* parser = [[[[self class] alloc] init] autorelease];
-			parser.identifier = [NSString stringWithFormat:@"%@:/%@",[[self class] identifier],libraryPath];
-			parser.mediaSource = [NSURL fileURLWithPath:libraryPath];
-			parser.mediaType = inMediaType;
-			parser.shouldDisplayLibraryName = libraryPaths.count > 1;
-					
-			if (! [parser checkDatabaseVersion]) {
-				continue;
-			}
-			
-			[parserInstances addObject:parser];
-		}
-	}
-	
+        for (NSString* libraryPath in libraryPaths) {
+            NSURL *libraryPathURL = [NSURL fileURLWithPath:libraryPath];
+            IMBResourceAccessibility libraryAccessibility = [libraryPathURL imb_accessibility];
+            
+            if (libraryAccessibility != kIMBResourceDoesNotExist) {
+                IMBLightroomModernParser* parser = [[[[self class] alloc] init] autorelease];
+                parser.identifier = [NSString stringWithFormat:@"%@:/%@",[[self class] identifier],libraryPath];
+                parser.mediaSource = libraryPathURL;
+                parser.mediaType = inMediaType;
+                parser.shouldDisplayLibraryName = libraryPaths.count > 1;
+                
+                // Check catalog compatibility. Defer if we lack access rights
+                if (libraryAccessibility == kIMBResourceIsAccessible) {
+                    if (! [parser checkDatabaseVersion]) {
+                        continue;
+                    }
+                }
+            
+                [parserInstances addObject:parser];
+            }
+        }
+    }
+    
 	return parserInstances;
 }
 
@@ -180,8 +189,33 @@
 // This method creates the immediate subnodes of the "Lightroom" root node. The two subnodes are "Folders"  
 // and "Collections"...
 
-- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode
+- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode error:(NSError**)outError
 {
+    if (! [self checkDatabaseVersion]) {
+        if (outError != NULL) {
+            NSString *lightroomVersion = [[self class] lightroomAppVersion];
+            NSString *localizedErrorDescriptionFormat = NSLocalizedStringWithDefaultValue(
+                                                                                          @"IMBLightroomParser.IncompatibleCatalogVersion",
+                                                                                          nil, IMBBundle(),
+                                                                                          @"This catalog does not appear to be compatible with Lightroom %@",
+                                                                                          @"Warning when Lightroom database version check fails");
+            NSString *localizedErrorDescription = [NSString stringWithFormat:localizedErrorDescriptionFormat, lightroomVersion];
+            
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
+                                      localizedErrorDescription, NSLocalizedDescriptionKey, nil];
+            
+            *outError = [NSError errorWithDomain:kIMBErrorDomain code:1 userInfo:userInfo];
+        }
+        
+        // Use empty array for subnodes and objects. This prevents further attempts at populating the node
+        [inRootNode mutableArrayForPopulatingSubnodes];
+        inRootNode.objects = [NSArray array];
+
+        //inRootNode.accessibility = kIMBResourceDoesNotExist;
+        
+        return;
+    }
+    
 	NSMutableArray* subnodes = [inRootNode mutableArrayForPopulatingSubnodes];
 	NSMutableArray* objects = [NSMutableArray array];
 	inRootNode.displayedObjectCount = 0;

--- a/IMBLightroomParser.h
+++ b/IMBLightroomParser.h
@@ -158,7 +158,7 @@ IMBLightroomNodeType;
 
 @interface IMBLightroomParser (Subclassers)
 
-- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode;
+- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode error:(NSError**)outError;
 - (void) populateSubnodesForRootFoldersNode:(IMBNode*)inFoldersNode;
 - (void) populateSubnodesForFolderNode:(IMBNode*)inParentNode;
 - (void) populateSubnodesForCollectionNode:(IMBNode*)inRootNode;

--- a/IMBLightroomParser.m
+++ b/IMBLightroomParser.m
@@ -368,8 +368,8 @@ static NSArray* sSupportedImageUTIs = nil;
 	// Create subnodes for the root node as needed...
 	
 	if ([inNode isTopLevelNode])
-	{
-		[self populateSubnodesForRootNode:inNode];
+    {
+        [self populateSubnodesForRootNode:inNode error:outError];
 	}
 	else {
 		NSDictionary* attributes = inNode.attributes;
@@ -686,7 +686,7 @@ static NSArray* sSupportedImageUTIs = nil;
 // This method creates the immediate subnodes of the "Lightroom" root node. The two subnodes are "Folders"  
 // and "Collections"...
 
-- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode
+- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode error:(NSError**)outError
 {
 	[self populateSubnodesForCollectionNode:inRootNode];
 }


### PR DESCRIPTION
If we lack access rights to the Lightroom library, we still create the parser and defer the compatibility check until population of the root node.