### PR TITLE
Fix a problem wherein bookmark removal was not being persisted...

### DIFF
--- a/IMBAccessRightsController.m
+++ b/IMBAccessRightsController.m
@@ -192,6 +192,18 @@ static NSString* kBookmarksPrefsKey = @"accessRightsBookmarks";
 	return nil;
 }
 
+- (void) removeBookmarks:(NSArray*)inBookmarks
+{
+    @synchronized(self)
+	{
+		for (NSData* bookmark in inBookmarks)
+		{
+			[self.bookmarks removeObject:bookmark];
+		}
+
+		[self saveToPrefs];
+	}
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -242,10 +254,7 @@ static NSString* kBookmarksPrefsKey = @"accessRightsBookmarks";
 		}
 	}
 
-	for (NSData* bookmark in bookmarksToRemove)
-	{
-		[self.bookmarks removeObject:bookmark];
-	}
+	[self removeBookmarks:bookmarksToRemove];
 }
 
 
@@ -366,7 +375,6 @@ static NSString* kBookmarksPrefsKey = @"accessRightsBookmarks";
 {
 	NSError* error = nil;
 	BOOL stale = NO;
-		
 	NSURL* url = [NSURL
 		URLByResolvingBookmarkData:inBookmark
 		options:NSURLBookmarkResolutionWithSecurityScope


### PR DESCRIPTION
Fix a problem wherein bookmark removal was not being persisted to disk. This was particularly vexing when for example the bookmark referred to a network mounted volume which no longer exists. The user impact was that iMedia tried each launch to resolve the bookmark, leading to an error alert displayed by the system about failing to mount the pertinent volume. Because the bookmarks were not being written back to disk after removal, the attempt to resolve would happen every time.

I fixed it by adding a new removeBookmarks: method through which all removal should funnel. It mirrors addBookmark: in its synchronization behavior and in calling saveToPrefs after it is done mutating the array.