### PR TITLE
Fix for failure to load LightroomCC catalogs when the LightroomCC application is not running

### DIFF
--- a/IMBLightroom4Parser.m
+++ b/IMBLightroom4Parser.m
@@ -168,7 +168,7 @@
 
 - (NSString*) iMedia2PersistentResourceIdentifierPrefix
 {
-	return @"IMBLightroom3Parser";
+	return @"IMBLightroom4Parser";
 }
 
 @end

--- a/IMBLightroom7Parser.m
+++ b/IMBLightroom7Parser.m
@@ -638,7 +638,7 @@
 - (FMDatabasePool*) createLibraryDatabasePool
 {
 	NSString* databasePath = [self.mediaSource path];
-	FMDatabasePool* databasePool = [[FMDatabasePool alloc] initWithPath:databasePath flags:SQLITE_OPEN_READONLY vfs:@"unix-none"];
+	FMDatabasePool* databasePool = [[FMDatabasePool alloc] initWithPath:databasePath flags:SQLITE_OPEN_READWRITE vfs:@"unix-none"];
 
 	return [databasePool autorelease];
 }
@@ -649,7 +649,7 @@
 	NSString* rootPath = [mainDatabasePath stringByDeletingPathExtension];
 	NSString* previewPackagePath = [[NSString stringWithFormat:@"%@ Previews", rootPath] stringByAppendingPathExtension:@"lrdata"];
 	NSString* previewDatabasePath = [[previewPackagePath stringByAppendingPathComponent:@"previews"] stringByAppendingPathExtension:@"db"];
-	FMDatabasePool* databasePool = [[FMDatabasePool alloc] initWithPath:previewDatabasePath flags:SQLITE_OPEN_READONLY vfs:@"unix-none"];
+	FMDatabasePool* databasePool = [[FMDatabasePool alloc] initWithPath:previewDatabasePath flags:SQLITE_OPEN_READWRITE vfs:@"unix-none"];
 
 	return [databasePool autorelease];
 }


### PR DESCRIPTION
It appears that the Lightroom7 database requires locking. The lock cannot be acquired when the database is opened in read-only mode. Thus we open it in read-write mode. The "unix-none" vfs is needed to ignore locks while the database is open in LightroomCC.