### PR TITLE
Quiet Xcode 9.3 #warning defines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: objective-c
-script: xctool -workspace iMedia.xcworkspace -scheme iMedia CODE_SIGN_IDENTITY=""
+osx_image: xcode9.3
+#xcode_workspace: iMedia.xcworkspace
+#xcode_scheme: iMedia
+script: xcodebuild build -workspace iMedia.xcworkspace -scheme iMedia CODE_SIGN_IDENTITY="" DEVELOPMENT_TEAM="" CODE_SIGNING_REQUIRED=NO

--- a/IMBCommon.h
+++ b/IMBCommon.h
@@ -238,9 +238,17 @@ typedef void (^IMBCompletionBlock)(id inResult,NSError* inError);
 #define IMBRunningOnMavericksOrNewer()		(NSAppKitVersionNumber >= NSAppKitVersionNumber10_9)
 #define IMBRunningOnYosemite10103OrNewer()  ([[NSProcessInfo processInfo] respondsToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10,10,3}])
 
-#define IMB_COMPILING_WITH_LION_OR_NEWER_SDK  defined(MAC_OS_X_VERSION_10_7)
-#define IMB_COMPILING_WITH_SNOW_LEOPARD_OR_NEWER_SDK  defined(MAC_OS_X_VERSION_10_6)
+#if defined(MAC_OS_X_VERSION_10_7)
+#define IMB_COMPILING_WITH_LION_OR_NEWER_SDK 1
+#else
+#define IMB_COMPILING_WITH_LION_OR_NEWER_SDK 0
+#endif
 
+#if defined(MAC_OS_X_VERSION_10_6)
+#define IMB_COMPILING_WITH_SNOW_LEOPARD_OR_NEWER_SDK 1
+#else
+#define IMB_COMPILING_WITH_SNOW_LEOPARD_OR_NEWER_SDK 0
+#endif
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/IMBObjectViewController.m
+++ b/IMBObjectViewController.m
@@ -2275,7 +2275,11 @@ static NSMutableDictionary* sRegisteredObjectViewControllerClasses = nil;
 		// the first Retina Macs didn't run 10.6, we can safely assume that where competent
 		// calculation of Retina-based frame is required, we will have the benefit of the
 		// new convenience method on NSWindow.
-#define USE_OLD_CONVERT_METHOD (!defined(MAC_OS_X_VERSION_10_7) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7))
+#if (!defined(MAC_OS_X_VERSION_10_7) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7))
+#define USE_OLD_CONVERT_METHOD 1
+#else
+#define USE_OLD_CONVERT_METHOD 0
+#endif
 #if USE_OLD_CONVERT_METHOD
 		if (IMBRunningOnLionOrNewer() == NO)
 		{


### PR DESCRIPTION
Just fixing the way Xcode recommends. I think they remain backward-comaptible to Xcode 9.2 and earlier.