### PR TITLE
Dealloc fixes

### DIFF
--- a/IMBObjectViewController.m
+++ b/IMBObjectViewController.m
@@ -358,7 +358,7 @@ static NSMutableDictionary* sRegisteredObjectViewControllerClasses = nil;
 
 	// Remove ourself from the QuickLook preview panel...
 	
-	QLPreviewPanel* panel = [QLPreviewPanel sharedPreviewPanel];
+	QLPreviewPanel* panel = [QLPreviewPanel sharedPreviewPanelExists] ? [QLPreviewPanel sharedPreviewPanel] : nil;
 	if (panel.delegate == (id)self) panel.delegate = nil;
 	if (panel.dataSource == (id)self) panel.dataSource = nil;
 	
@@ -1075,7 +1075,7 @@ static NSMutableDictionary* sRegisteredObjectViewControllerClasses = nil;
 {
 	// Notify the Quicklook panel of the selection change...
 	
-	QLPreviewPanel* panel = [QLPreviewPanel sharedPreviewPanel];
+	QLPreviewPanel* panel = [QLPreviewPanel sharedPreviewPanelExists] ? [QLPreviewPanel sharedPreviewPanel] : nil;
 	
 	if (panel.dataSource == (id)self)
 	{

--- a/fmdb/src/fmdb/FMDatabasePool.m
+++ b/fmdb/src/fmdb/FMDatabasePool.m
@@ -77,8 +77,9 @@
     _delegate = 0x00;
     FMDBRelease(_path);
     FMDBRelease(_databaseInPool);
-    FMDBRelease(_databaseOutPool);
-    
+	FMDBRelease(_databaseOutPool);
+	FMDBRelease(_vfsName);
+
     if (_lockQueue) {
         FMDBDispatchQueueRelease(_lockQueue);
         _lockQueue = 0x00;

--- a/fmdb/src/fmdb/FMDatabaseQueue.m
+++ b/fmdb/src/fmdb/FMDatabaseQueue.m
@@ -108,6 +108,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
     
     FMDBRelease(_db);
     FMDBRelease(_path);
+	FMDBRelease(_vfsName);
     
     if (_queue) {
         FMDBDispatchQueueRelease(_queue);


### PR DESCRIPTION
- Added missing release for _vfsName
- Avoid creating an instance of QLPreviewPanel during dealloc of delegate/datasource 