### PR TITLE
Fallback for Apple Photos group icons

### DIFF
--- a/IMBAppleMediaLibraryParser.m
+++ b/IMBAppleMediaLibraryParser.m
@@ -404,12 +404,9 @@ NSString *kIMBMLMediaGroupTypeFacesFolder = @"FacesFolder";
 											  withMappingTable:&kIconTypeMapping
 													 highlight:NO
 								  considerGenericFallbackImage:NO];
-
-			if (icon == nil) {
-				NSLog(@"%@", typeIdentifier);
-			}
 		}
     }
+	
     node.icon = icon;
     node.highlightIcon = highlightIcon;
     node.name = [self localizedNameForMediaGroup:mediaGroup];


### PR DESCRIPTION
Apple Photos group icons often fail to load on High Sierra. This provides a fallback by loading icon files from the application bundle.

Again: it's a bit of a hack since it is specific to Apple Photos, yet the code is in a parser that could handle any MLMediaLibrary

Fixes iMediaSandboxing/iMedia#102