### PR TITLE
 Lightroom 13.3 support

### DIFF
--- a/IMBLightroomModernParser.h
+++ b/IMBLightroomModernParser.h
@@ -63,12 +63,20 @@
 
 - (NSNumber*) databaseVersion;
 
-- (BOOL)usesLrprevPyramidFiles;
+// The resolved path points to either a .lrprev pyramid or to the largest available preview image
++ (NSString*) resolvedPyramidPathWithPyramidPath:(NSString *)absolutePyramidPath
+									preferLrprev:(BOOL)preferLrprev
+						   acceptAlternateDigest:(BOOL)acceptAlternateDigest;
 
-+ (NSData*) previewDataWithPyramidPath:(NSString *)absolutePyramidPath
-						   maximumSize:(NSNumber*)maximumSize
-						  preferLrprev:(BOOL)preferLrprev
-				 acceptAlternateDigest:(BOOL)acceptAlternateDigest;
+// Provides JPEG data. Finds the appropriate segment of the .lrprev or appropriate image file
+// The image data still needs to be adjusted to match the correct image orientation
++ (NSData*) previewDataWithResolvedPyramidPath:(NSString*)resolvedPyramidPath
+								   maximumSize:(NSNumber*)maximumSize;
+
+//+ (NSData*) previewDataWithPyramidPath:(NSString *)absolutePyramidPath
+//						   maximumSize:(NSNumber*)maximumSize
+//						  preferLrprev:(BOOL)preferLrprev
+//				 acceptAlternateDigest:(BOOL)acceptAlternateDigest;
 
 @end
 

--- a/IMBLightroomModernParser.h
+++ b/IMBLightroomModernParser.h
@@ -58,12 +58,17 @@
 
 @interface IMBLightroomModernParser : IMBLightroomParser <IMBLightroomParser>
 {
-	
+	NSNumber* _usesLrprevPyramidFiles;
 }
 
 - (NSNumber*) databaseVersion;
 
-+ (NSData*) previewDataForLightroomObject:(IMBLightroomObject*)lightroomObject maximumSize:(NSNumber*)maximumSize;
+- (BOOL)usesLrprevPyramidFiles;
+
++ (NSData*) previewDataWithPyramidPath:(NSString *)absolutePyramidPath
+						   maximumSize:(NSNumber*)maximumSize
+						  preferLrprev:(BOOL)preferLrprev
+				 acceptAlternateDigest:(BOOL)acceptAlternateDigest;
 
 @end
 

--- a/IMBLightroomModernParser.m
+++ b/IMBLightroomModernParser.m
@@ -292,30 +292,99 @@
 	__block NSString *uuid = nil;
 	__block NSString *digest = nil;
 
-	[self inLibraryDatabase:^(FMDatabase *libraryDatabase) {
-		if (libraryDatabase == nil) {
+	[self inThumbnailDatabase:^(FMDatabase *thumbnailDatabase) {
+		if (thumbnailDatabase == nil) {
 			return;
 		}
-		
-		NSString* query =	@" SELECT alf.id_global uuid, ids.digest"
-		@" FROM Adobe_imageDevelopSettings ids"
-		@" INNER JOIN Adobe_images ai ON ai.id_local = ids.image"
-		@" INNER JOIN AgLibraryFile alf on alf.id_local = ai.rootFile"
-		@" WHERE ids.image = ?"
-		@" ORDER BY alf.id_global ASC";
 
-		FMResultSet* results = [libraryDatabase executeQuery:query, idLocal];
+		NSString* query =	@" SELECT ice.imageId AS image_id,  p.uuid, p.digest"
+		@" FROM Pyramid p"
+		@" JOIN ImageCacheEntry ice ON ice.uuid = p.uuid"
+		@" WHERE image_id = ?";
 
-        // JJ/2012-10-02: For some reason we may get multiple rows with some of them not properly filled. Try best we can.
+		FMResultSet* results = [thumbnailDatabase executeQuery:query, idLocal];
 
-        while ([results next] && (uuid == nil || digest == nil || [uuid isEqualToString:@""] || [digest isEqualToString:@""]))
-        {
+		while ([results next] && ([digest length] == 0))
+		{
 			uuid = [results stringForColumn:@"uuid"];
 			digest = [results stringForColumn:@"digest"];
-        }
+		}
 
 		[results close];
 	}];
+
+#if 0
+	if (digest == nil) {
+		[self inLibraryDatabase:^(FMDatabase *libraryDatabase) {
+			if (libraryDatabase == nil) {
+				return;
+			}
+
+			NSString* query =	@" SELECT alf.id_global uuid"
+			@" FROM Adobe_images ai"
+			@" INNER JOIN AgLibraryFile alf on alf.id_local = ai.rootFile"
+			@" WHERE ai.id_local = ?";
+
+			FMResultSet* results = [libraryDatabase executeQuery:query, idLocal];
+
+			while ([results next] && ([uuid length] == 0))
+			{
+				uuid = [results stringForColumn:@"uuid"];
+			}
+
+			[results close];
+		}];
+
+		if (uuid != nil) {
+			[self inThumbnailDatabase:^(FMDatabase *thumbnailDatabase) {
+				if (thumbnailDatabase == nil) {
+					return;
+				}
+
+				NSString* query =	@" SELECT p.digest"
+				@" FROM Pyramid p"
+				@" WHERE p.uuid = ?";
+
+				FMResultSet* results = [thumbnailDatabase executeQuery:query, uuid];
+
+				while ([results next] && ([digest length] == 0))
+				{
+					digest = [results stringForColumn:@"digest"];
+				}
+
+				[results close];
+			}];
+		}
+	}
+#endif
+
+	if (digest == nil) {
+		[self inLibraryDatabase:^(FMDatabase *libraryDatabase) {
+			if (libraryDatabase == nil) {
+				return;
+			}
+
+			NSString* query =	@" SELECT alf.id_global uuid, ids.digest"
+			@" FROM Adobe_imageDevelopSettings ids"
+			@" INNER JOIN Adobe_images ai ON ai.id_local = ids.image"
+			@" INNER JOIN AgLibraryFile alf on alf.id_local = ai.rootFile"
+			@" WHERE ids.image = ?"
+			@" ORDER BY alf.id_global ASC";
+
+			FMResultSet* results = [libraryDatabase executeQuery:query, idLocal];
+
+			// JJ/2012-10-02: For some reason we may get multiple rows with some of them not properly filled. Try best we can.
+			// Pierre/2024-11-15: Check Adobe_libraryImageDevelopHistoryStep for digests ordered by date
+			
+			while ([results next] && (uuid == nil || digest == nil || [uuid isEqualToString:@""] || [digest isEqualToString:@""]))
+			{
+				uuid = [results stringForColumn:@"uuid"];
+				digest = [results stringForColumn:@"digest"];
+			}
+
+			[results close];
+		}];
+	}
 
 	if ((uuid != nil) && (digest != nil)) {
 		NSString* prefixOne = [uuid substringToIndex:1];
@@ -328,109 +397,309 @@
 	return nil;
 }
 
+- (BOOL)usesLrprevPyramidFiles
+{
+	if (_usesLrprevPyramidFiles == nil) {
+		NSNumber* databaseVersion = [self databaseVersion];
+		long databaseVersionLong = [databaseVersion longValue];
+		BOOL usesLrprevPyramidFiles = (databaseVersionLong < 1303000);
+
+		_usesLrprevPyramidFiles = [NSNumber numberWithBool:usesLrprevPyramidFiles];
+	}
+
+	return [_usesLrprevPyramidFiles boolValue];
+}
+
 - (NSData*) previewDataForObject:(IMBObject*)inObject maximumSize:(NSNumber*)maximumSize
 {
 	if ([inObject isKindOfClass:[IMBLightroomObject class]]) {
-		return [[self class] previewDataForLightroomObject:(IMBLightroomObject *)inObject maximumSize:maximumSize];
+		BOOL preferLrprev = [self usesLrprevPyramidFiles];
+		NSString* absolutePyramidPath = [(IMBLightroomObject*)inObject absolutePyramidPath];
+
+		return [[self class] previewDataWithPyramidPath:absolutePyramidPath maximumSize:maximumSize preferLrprev:preferLrprev acceptAlternateDigest:YES];
 	}
 
 	return nil;
 }
 
-+ (NSData*) previewDataForLightroomObject:(IMBLightroomObject*)lightroomObject maximumSize:(NSNumber*)maximumSize
++ (NSData*) previewDataWithPyramidPath:(NSString *)absolutePyramidPath
+						   maximumSize:(NSNumber*)maximumSize
+						  preferLrprev:(BOOL)preferLrprev
+				 acceptAlternateDigest:(BOOL)acceptAlternateDigest
 {
-	NSString* absolutePyramidPath = [lightroomObject absolutePyramidPath];
+	// Starting with Lightroom 13.3, previews are no longer stored in a .lrprev file.
+	// Instead Lightroom 13.3, creates individual JPEG files with no extension.
+	// These files retain the same uuid-digest basename as the .lrprev file and add a suffix specifying the dimension
+
+	// https://community.adobe.com/t5/lightroom-classic-discussions/upgrading-catalog-with-13-3-loses-previews/m-p/14659945
+	// https://community.adobe.com/t5/lightroom-classic-discussions/preview-files-have-multiplied/m-p/14845368
+
+	// Lightroom 13.3 probably maps to database version 1303000
+	// Lightroom migrates lprev files as needed. An upgraded library has a mix of JPEG an .lrprev previews
+
 	NSData* data = nil;
 
-	if (absolutePyramidPath != nil) {
-		data = [NSData dataWithContentsOfMappedFile:absolutePyramidPath];
+	if (preferLrprev) {
+		data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+
+		if (data == nil) {
+			data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		}
+	}
+	else {
+		data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+
+		if (data == nil) {
+			data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		}
 	}
 
 	if (data != nil) {
-		NSData* data = [NSData dataWithContentsOfMappedFile:absolutePyramidPath];
-
-		//		'AgHg'					-- a magic marker
-		//		header length			-- 2 bytes, big endian includes marker and length
-		//		version					-- 1 byte, zero for now
-		//		kind					-- 1 bytes, 0 == string, 1 == blob
-		//		data length				-- 8 bytes, big endian
-		//		data padding length		-- 8 bytes, big endian
-		//		name					-- zero terminated
-		//		< padding for rest of header >
-		//		< data >
-		//		< data padding >
-
-		const char pattern[4] = { 0x41, 0x67, 0x48, 0x67 };
-
-		NSUInteger index = NSNotFound;
-
-		if (maximumSize == nil) {
-			index = [data lastIndexOfBytes:pattern length:4];
-		}
-		else {
-			index = [data indexOfBytes:pattern length:4];
-		}
-
-		NSData* previousData = nil;
-		CGFloat maximumSizeFloat = [maximumSize floatValue];
-
-		while (index != NSNotFound) {
-			unsigned short headerLengthValue; // size 2
-			unsigned long long dataLengthValue; // size 8
-
-			[data getBytes:&headerLengthValue range:NSMakeRange(index + 4, 2)];
-			[data getBytes:&dataLengthValue range:NSMakeRange(index + 4 + 2 + 1 + 1, 8)];
-
-			headerLengthValue = NSSwapBigShortToHost(headerLengthValue);
-			dataLengthValue = NSSwapBigLongLongToHost(dataLengthValue);
-
-			NSData* jpegData = nil;
-
-            if ((index + headerLengthValue + dataLengthValue) <= [data length]) {
-                jpegData = [data subdataWithRange:NSMakeRange(index + headerLengthValue, dataLengthValue)];
-            }
-			else {
-				break;
-			}
-
-			if (maximumSize == nil) {
-				return jpegData;
-			}
-
-			if (previousData == nil) {
-				previousData = jpegData;
-			}
-
-			if (jpegData != nil) {
-				CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)jpegData, nil);
-
-				if (source != NULL) {
-					CGImageRef imageRepresentation = CGImageSourceCreateImageAtIndex(source, 0, NULL);
-
-					CFRelease(source);
-
-					if (imageRepresentation != NULL) {
-						CGFloat width = CGImageGetWidth(imageRepresentation);
-						CGFloat height = CGImageGetHeight(imageRepresentation);
-
-						CFRelease(imageRepresentation);
-
-						if ((width > maximumSizeFloat) || (height > maximumSizeFloat)) {
-							break;
-						}
-					}
-
-					previousData = jpegData;
-				}
-			}
-
-			index = [data indexOfBytes:pattern length:4 options:0 range:NSMakeRange(index + 4, [data length] - index - 4)];
-		}
-
-		return previousData;
+		return data;
 	}
 
-	return nil;
+	if (acceptAlternateDigest) {
+		if (preferLrprev) {
+			data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+
+			if (data == nil) {
+				data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			}
+		}
+		else {
+			data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+
+			if (data == nil) {
+				data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			}
+		}
+	}
+
+	return data;
+}
+
+//------------------------------------
++ (NSData*) previewDataFromLrprevWithPyramidPath:(NSString *)absolutePyramidPath
+									 maximumSize:(NSNumber*)maximumSize
+						   acceptAlternateDigest:(BOOL)acceptAlternateDigest
+{
+	if (absolutePyramidPath == nil) {
+		return nil;
+	}
+
+	NSString* lrprevFilePath = absolutePyramidPath;
+	NSFileManager* fileManager = [NSFileManager defaultManager];
+
+	if (![fileManager fileExistsAtPath:lrprevFilePath]) {
+		NSString* alternatePath = nil;
+
+		if (acceptAlternateDigest) {
+			NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
+			NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
+			NSRange lastDashRange = [baseName rangeOfString:@"-" options:NSBackwardsSearch];
+
+			if (lastDashRange.location != NSNotFound) {
+				NSString* prefix = [baseName substringToIndex:(lastDashRange.location + 1)];
+				NSError* fileManagerError = nil;
+				NSArray* allFiles = [fileManager contentsOfDirectoryAtPath:absoluteFolderPath error:&fileManagerError];
+
+				if (allFiles == nil) {
+					NSLog(@"Lightroom parser. Directory listing error: %@", fileManagerError);
+
+					return nil;
+				}
+
+				for (NSString* fileName in allFiles) {
+					if ([fileName hasPrefix:prefix] && [[fileName pathExtension] isEqual:@"lrprev"]) {
+						alternatePath = [absoluteFolderPath stringByAppendingPathComponent:fileName];
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (alternatePath != nil) {
+			lrprevFilePath = alternatePath;
+		}
+		else {
+			NSLog(@"Lightroom parser. File not found: %@", absolutePyramidPath);
+		}
+	}
+
+	NSURL* lrprevFileURL = [NSURL fileURLWithPath:lrprevFilePath isDirectory:NO];
+	NSError* dataError = nil;
+	NSData* data = [NSData dataWithContentsOfURL:lrprevFileURL options:NSDataReadingMappedIfSafe error:&dataError];
+
+	if (data == nil) {
+		NSLog(@"Lightroom parser. File read error: %@", dataError);
+
+		return nil;
+	}
+
+	//		'AgHg'					-- a magic marker
+	//		header length			-- 2 bytes, big endian includes marker and length
+	//		version					-- 1 byte, zero for now
+	//		kind					-- 1 bytes, 0 == string, 1 == blob
+	//		data length				-- 8 bytes, big endian
+	//		data padding length		-- 8 bytes, big endian
+	//		name					-- zero terminated
+	//		< padding for rest of header >
+	//		< data >
+	//		< data padding >
+
+	const char pattern[4] = { 0x41, 0x67, 0x48, 0x67 };
+
+	NSUInteger index = NSNotFound;
+
+	if (maximumSize == nil) {
+		index = [data lastIndexOfBytes:pattern length:4];
+	}
+	else {
+		index = [data indexOfBytes:pattern length:4];
+	}
+
+	NSData* previousData = nil;
+	CGFloat maximumSizeFloat = [maximumSize floatValue];
+
+	while (index != NSNotFound) {
+		unsigned short headerLengthValue; // size 2
+		unsigned long long dataLengthValue; // size 8
+
+		[data getBytes:&headerLengthValue range:NSMakeRange(index + 4, 2)];
+		[data getBytes:&dataLengthValue range:NSMakeRange(index + 4 + 2 + 1 + 1, 8)];
+
+		headerLengthValue = NSSwapBigShortToHost(headerLengthValue);
+		dataLengthValue = NSSwapBigLongLongToHost(dataLengthValue);
+
+		NSData* jpegData = nil;
+
+		if ((index + headerLengthValue + dataLengthValue) <= [data length]) {
+			jpegData = [data subdataWithRange:NSMakeRange(index + headerLengthValue, dataLengthValue)];
+		}
+		else {
+			break;
+		}
+
+		if (maximumSize == nil) {
+			return jpegData;
+		}
+
+		if (previousData == nil) {
+			previousData = jpegData;
+		}
+
+		if (jpegData != nil) {
+			CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)jpegData, nil);
+
+			if (source != NULL) {
+				CGImageRef imageRepresentation = CGImageSourceCreateImageAtIndex(source, 0, NULL);
+
+				CFRelease(source);
+
+				if (imageRepresentation != NULL) {
+					CGFloat width = CGImageGetWidth(imageRepresentation);
+					CGFloat height = CGImageGetHeight(imageRepresentation);
+
+					CFRelease(imageRepresentation);
+
+					if ((width > maximumSizeFloat) || (height > maximumSizeFloat)) {
+						break;
+					}
+				}
+
+				previousData = jpegData;
+			}
+		}
+
+		index = [data indexOfBytes:pattern length:4 options:0 range:NSMakeRange(index + 4, [data length] - index - 4)];
+	}
+
+	return previousData;
+}
+
++ (NSData*) previewDataFromFilesWithPyramidPath:(NSString *)absolutePyramidPath
+									maximumSize:(NSNumber*)maximumSize
+						  acceptAlternateDigest:(BOOL)acceptAlternateDigest
+{
+	if (absolutePyramidPath == nil) {
+		return nil;
+	}
+
+	NSFileManager* fileManager = [NSFileManager defaultManager];
+	NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
+	NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
+
+	NSError* fileManagerError = nil;
+	NSArray* allFiles = [fileManager contentsOfDirectoryAtPath:absoluteFolderPath error:&fileManagerError];
+
+	if (allFiles == nil) {
+		NSLog(@"Lightroom parser. Directory listing error: %@", fileManagerError);
+
+		return nil;
+	}
+
+	NSString* regexPattern = [NSString stringWithFormat:@"%@_(\\d+)$", baseName];
+
+	if (acceptAlternateDigest) {
+		NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
+		NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
+		NSRange lastDashRange = [baseName rangeOfString:@"-" options:NSBackwardsSearch];
+
+		if (lastDashRange.location != NSNotFound) {
+			NSString* uuid = [baseName substringToIndex:lastDashRange.location];
+
+			regexPattern = [NSString stringWithFormat:@"%@-[a-z0-9]+_(\\d+)$", uuid];
+		}
+	}
+
+	NSError* regexError = nil;
+	NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexPattern
+																		   options:0
+																			 error:&regexError];
+
+	if (regex == nil) {
+		NSLog(@"Lightroom parser. Regular expression error: %@", regexError);
+
+		return nil;
+	}
+
+	NSString* bestMatchFileName = nil;
+	NSInteger bestMatchSizeValue = NSNotFound;
+	NSInteger maximumSizeValue = (maximumSize != nil) ? [maximumSize integerValue] : NSIntegerMax;
+
+	for (NSString* fileName in allFiles) {
+		NSRange range = NSMakeRange(0, fileName.length);
+		NSTextCheckingResult* match = [regex firstMatchInString:fileName options:0 range:range];
+
+		if (match) {
+			NSRange sizeRange = [match rangeAtIndex:1];
+			NSString* sizeString = [fileName substringWithRange:sizeRange];
+			NSInteger sizeValue = [sizeString integerValue];
+
+			if ((bestMatchFileName == nil) || ((sizeValue > bestMatchSizeValue) && (sizeValue <= maximumSizeValue))) {
+				bestMatchFileName = fileName;
+				bestMatchSizeValue = sizeValue;
+			}
+		}
+	}
+
+	if (bestMatchFileName == nil) {
+		return nil;
+	}
+
+	NSString* bestMatchFilePath = [absoluteFolderPath stringByAppendingPathComponent:bestMatchFileName];
+	NSURL* bestMatchFileURL = [NSURL fileURLWithPath:bestMatchFilePath isDirectory:NO];
+	NSError* dataError = nil;
+	NSData* data = [NSData dataWithContentsOfURL:bestMatchFileURL options:NSDataReadingMappedIfSafe error:&dataError];
+
+	if (data == nil) {
+		NSLog(@"Lightroom parser. File read error: %@", dataError);
+
+		return nil;
+	}
+
+	return data;
 }
 
 

--- a/IMBLightroomModernParser.m
+++ b/IMBLightroomModernParser.m
@@ -416,7 +416,7 @@
 		BOOL preferLrprev = [self usesLrprevPyramidFiles];
 		NSString* absolutePyramidPath = [(IMBLightroomObject*)inObject absolutePyramidPath];
 
-		return [[self class] previewDataWithPyramidPath:absolutePyramidPath maximumSize:maximumSize preferLrprev:preferLrprev acceptAlternateDigest:YES];
+		return [[self class] previewDataWithPyramidPath:absolutePyramidPath maximumSize:maximumSize preferLrprev:preferLrprev acceptAlternateDigest:NO];
 	}
 
 	return nil;

--- a/IMBLightroomModernParser.m
+++ b/IMBLightroomModernParser.m
@@ -413,19 +413,33 @@
 - (NSData*) previewDataForObject:(IMBObject*)inObject maximumSize:(NSNumber*)maximumSize
 {
 	if ([inObject isKindOfClass:[IMBLightroomObject class]]) {
-		BOOL preferLrprev = [self usesLrprevPyramidFiles];
 		NSString* absolutePyramidPath = [(IMBLightroomObject*)inObject absolutePyramidPath];
 
-		return [[self class] previewDataWithPyramidPath:absolutePyramidPath maximumSize:maximumSize preferLrprev:preferLrprev acceptAlternateDigest:NO];
+		if (absolutePyramidPath == nil) {
+			return nil;
+		}
+
+		NSString* resolvedPyramidPath = [(IMBLightroomObject*)inObject resolvedPyramidPath];
+
+		if (resolvedPyramidPath == nil) {
+			BOOL preferLrprev = [self usesLrprevPyramidFiles];
+
+			resolvedPyramidPath = [[self class] resolvedPyramidPathWithPyramidPath:absolutePyramidPath preferLrprev:preferLrprev acceptAlternateDigest:NO];
+		}
+
+		if (resolvedPyramidPath == nil) {
+			return nil;
+		}
+
+		return [[self class] previewDataWithResolvedPyramidPath:resolvedPyramidPath maximumSize:maximumSize];
 	}
 
 	return nil;
 }
 
-+ (NSData*) previewDataWithPyramidPath:(NSString *)absolutePyramidPath
-						   maximumSize:(NSNumber*)maximumSize
-						  preferLrprev:(BOOL)preferLrprev
-				 acceptAlternateDigest:(BOOL)acceptAlternateDigest
++ (NSString*) resolvedPyramidPathWithPyramidPath:(NSString *)absolutePyramidPath
+									preferLrprev:(BOOL)preferLrprev
+						   acceptAlternateDigest:(BOOL)acceptAlternateDigest
 {
 	// Starting with Lightroom 13.3, previews are no longer stored in a .lrprev file.
 	// Instead Lightroom 13.3, creates individual JPEG files with no extension.
@@ -437,51 +451,49 @@
 	// Lightroom 13.3 probably maps to database version 1303000
 	// Lightroom migrates lprev files as needed. An upgraded library has a mix of JPEG an .lrprev previews
 
-	NSData* data = nil;
+	NSString* resolvedPyramidPath = nil;
 
 	if (preferLrprev) {
-		data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		resolvedPyramidPath = [self resolvedPyramidLrprevPathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:NO];
 
-		if (data == nil) {
-			data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		if (resolvedPyramidPath == nil) {
+			resolvedPyramidPath = [self resolvedPyramidImagePathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:NO];
 		}
 	}
 	else {
-		data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		resolvedPyramidPath = [self resolvedPyramidImagePathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:NO];
 
-		if (data == nil) {
-			data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:NO];
+		if (resolvedPyramidPath == nil) {
+			resolvedPyramidPath = [self resolvedPyramidLrprevPathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:NO];
 		}
 	}
 
-	if (data != nil) {
-		return data;
+	if (resolvedPyramidPath != nil) {
+		return resolvedPyramidPath;
 	}
 
 	if (acceptAlternateDigest) {
 		if (preferLrprev) {
-			data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			resolvedPyramidPath = [self resolvedPyramidLrprevPathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:YES];
 
-			if (data == nil) {
-				data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			if (resolvedPyramidPath == nil) {
+				resolvedPyramidPath = [self resolvedPyramidImagePathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:YES];
 			}
 		}
 		else {
-			data = [self previewDataFromFilesWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			resolvedPyramidPath = [self resolvedPyramidImagePathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:YES];
 
-			if (data == nil) {
-				data = [self previewDataFromLrprevWithPyramidPath:absolutePyramidPath maximumSize:maximumSize acceptAlternateDigest:YES];
+			if (resolvedPyramidPath == nil) {
+				resolvedPyramidPath = [self resolvedPyramidLrprevPathWithPyramidPath:absolutePyramidPath acceptAlternateDigest:YES];
 			}
 		}
 	}
 
-	return data;
+	return resolvedPyramidPath;
 }
 
-//------------------------------------
-+ (NSData*) previewDataFromLrprevWithPyramidPath:(NSString *)absolutePyramidPath
-									 maximumSize:(NSNumber*)maximumSize
-						   acceptAlternateDigest:(BOOL)acceptAlternateDigest
++ (NSString*) resolvedPyramidLrprevPathWithPyramidPath:(NSString *)absolutePyramidPath
+								 acceptAlternateDigest:(BOOL)acceptAlternateDigest
 {
 	if (absolutePyramidPath == nil) {
 		return nil;
@@ -525,6 +537,106 @@
 		else {
 			NSLog(@"Lightroom parser. File not found: %@", absolutePyramidPath);
 		}
+	}
+
+	return lrprevFilePath;
+}
+
++ (NSString*) resolvedPyramidImagePathWithPyramidPath:(NSString *)absolutePyramidPath
+								acceptAlternateDigest:(BOOL)acceptAlternateDigest
+{
+	if (absolutePyramidPath == nil) {
+		return nil;
+	}
+
+	NSFileManager* fileManager = [NSFileManager defaultManager];
+	NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
+	NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
+
+	NSError* fileManagerError = nil;
+	NSArray* allFiles = [fileManager contentsOfDirectoryAtPath:absoluteFolderPath error:&fileManagerError];
+
+	if (allFiles == nil) {
+		NSLog(@"Lightroom parser. Directory listing error: %@", fileManagerError);
+
+		return nil;
+	}
+
+	NSString* regexPattern = [NSString stringWithFormat:@"%@_(\\d+)$", baseName];
+
+	if (acceptAlternateDigest) {
+		NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
+		NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
+		NSRange lastDashRange = [baseName rangeOfString:@"-" options:NSBackwardsSearch];
+
+		if (lastDashRange.location != NSNotFound) {
+			NSString* uuid = [baseName substringToIndex:lastDashRange.location];
+
+			regexPattern = [NSString stringWithFormat:@"%@-[a-z0-9]+_(\\d+)$", uuid];
+		}
+	}
+
+	NSError* regexError = nil;
+	NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexPattern
+																		   options:0
+																			 error:&regexError];
+
+	if (regex == nil) {
+		NSLog(@"Lightroom parser. Regular expression error: %@", regexError);
+
+		return nil;
+	}
+
+	NSString* bestMatchFileName = nil;
+	NSInteger bestMatchSizeValue = NSNotFound;
+
+	for (NSString* fileName in allFiles) {
+		NSRange range = NSMakeRange(0, fileName.length);
+		NSTextCheckingResult* match = [regex firstMatchInString:fileName options:0 range:range];
+
+		if (match) {
+			NSRange sizeRange = [match rangeAtIndex:1];
+			NSString* sizeString = [fileName substringWithRange:sizeRange];
+			NSInteger sizeValue = [sizeString integerValue];
+
+			if ((bestMatchFileName == nil) || (sizeValue > bestMatchSizeValue)) {
+				bestMatchFileName = fileName;
+				bestMatchSizeValue = sizeValue;
+			}
+		}
+	}
+
+	if (bestMatchFileName == nil) {
+		return nil;
+	}
+
+	NSString* bestMatchFilePath = [absoluteFolderPath stringByAppendingPathComponent:bestMatchFileName];
+
+	return bestMatchFilePath;
+}
+
++ (NSData*) previewDataWithResolvedPyramidPath:(NSString*)resolvedPyramidPath
+								   maximumSize:(NSNumber*)maximumSize
+{
+	if (resolvedPyramidPath == nil) {
+		return nil;
+	}
+
+	if ([[resolvedPyramidPath pathExtension] isEqual:@"lrprev"]) {
+		return [self previewDataFormPyramidLrprevPath:resolvedPyramidPath maximumSize:maximumSize];
+	}
+	else {
+		return [self previewDataFromPyramidImagePath:resolvedPyramidPath maximumSize:maximumSize];
+	}
+
+	return nil;
+}
+
++ (NSData*) previewDataFormPyramidLrprevPath:(NSString *)lrprevFilePath
+								 maximumSize:(NSNumber*)maximumSize
+{
+	if (lrprevFilePath == nil) {
+		return nil;
 	}
 
 	NSURL* lrprevFileURL = [NSURL fileURLWithPath:lrprevFilePath isDirectory:NO];
@@ -618,77 +730,78 @@
 	return previousData;
 }
 
-+ (NSData*) previewDataFromFilesWithPyramidPath:(NSString *)absolutePyramidPath
-									maximumSize:(NSNumber*)maximumSize
-						  acceptAlternateDigest:(BOOL)acceptAlternateDigest
++ (NSData*) previewDataFromPyramidImagePath:(NSString*)pyramidImagePath
+								maximumSize:(NSNumber*)maximumSize
 {
-	if (absolutePyramidPath == nil) {
+	if (pyramidImagePath == nil) {
 		return nil;
 	}
 
+	NSString* bestMatchFilePath = nil;
 	NSFileManager* fileManager = [NSFileManager defaultManager];
-	NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
-	NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
 
-	NSError* fileManagerError = nil;
-	NSArray* allFiles = [fileManager contentsOfDirectoryAtPath:absoluteFolderPath error:&fileManagerError];
-
-	if (allFiles == nil) {
-		NSLog(@"Lightroom parser. Directory listing error: %@", fileManagerError);
-
-		return nil;
+	if ((maximumSize == nil) && ([fileManager isReadableFileAtPath:pyramidImagePath])) {
+		bestMatchFilePath = pyramidImagePath;
 	}
 
-	NSString* regexPattern = [NSString stringWithFormat:@"%@_(\\d+)$", baseName];
+	if (bestMatchFilePath == nil) {
+		NSString* absoluteFolderPath = [pyramidImagePath stringByDeletingLastPathComponent];
+		NSString* baseName = [[pyramidImagePath lastPathComponent] stringByDeletingPathExtension];
+		NSRange lastUnderscoreRange = [baseName rangeOfString:@"_" options:NSBackwardsSearch];
 
-	if (acceptAlternateDigest) {
-		NSString* absoluteFolderPath = [absolutePyramidPath stringByDeletingLastPathComponent];
-		NSString* baseName = [[absolutePyramidPath lastPathComponent] stringByDeletingPathExtension];
-		NSRange lastDashRange = [baseName rangeOfString:@"-" options:NSBackwardsSearch];
-
-		if (lastDashRange.location != NSNotFound) {
-			NSString* uuid = [baseName substringToIndex:lastDashRange.location];
-
-			regexPattern = [NSString stringWithFormat:@"%@-[a-z0-9]+_(\\d+)$", uuid];
+		if (lastUnderscoreRange.location != NSNotFound) {
+			baseName = [baseName substringToIndex:lastUnderscoreRange.location];
 		}
-	}
 
-	NSError* regexError = nil;
-	NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexPattern
-																		   options:0
-																			 error:&regexError];
+		NSError* fileManagerError = nil;
+		NSArray* allFiles = [fileManager contentsOfDirectoryAtPath:absoluteFolderPath error:&fileManagerError];
 
-	if (regex == nil) {
-		NSLog(@"Lightroom parser. Regular expression error: %@", regexError);
+		if (allFiles == nil) {
+			NSLog(@"Lightroom parser. Directory listing error: %@", fileManagerError);
 
-		return nil;
-	}
+			return nil;
+		}
 
-	NSString* bestMatchFileName = nil;
-	NSInteger bestMatchSizeValue = NSNotFound;
-	NSInteger maximumSizeValue = (maximumSize != nil) ? [maximumSize integerValue] : NSIntegerMax;
+		NSString* regexPattern = [NSString stringWithFormat:@"%@_(\\d+)$", baseName];
 
-	for (NSString* fileName in allFiles) {
-		NSRange range = NSMakeRange(0, fileName.length);
-		NSTextCheckingResult* match = [regex firstMatchInString:fileName options:0 range:range];
+		NSError* regexError = nil;
+		NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexPattern
+																			   options:0
+																				 error:&regexError];
 
-		if (match) {
-			NSRange sizeRange = [match rangeAtIndex:1];
-			NSString* sizeString = [fileName substringWithRange:sizeRange];
-			NSInteger sizeValue = [sizeString integerValue];
+		if (regex == nil) {
+			NSLog(@"Lightroom parser. Regular expression error: %@", regexError);
 
-			if ((bestMatchFileName == nil) || ((sizeValue > bestMatchSizeValue) && (sizeValue <= maximumSizeValue))) {
-				bestMatchFileName = fileName;
-				bestMatchSizeValue = sizeValue;
+			return nil;
+		}
+
+		NSString* bestMatchFileName = nil;
+		NSInteger bestMatchSizeValue = NSNotFound;
+		NSInteger maximumSizeValue = (maximumSize != nil) ? [maximumSize integerValue] : NSIntegerMax;
+
+		for (NSString* fileName in allFiles) {
+			NSRange range = NSMakeRange(0, fileName.length);
+			NSTextCheckingResult* match = [regex firstMatchInString:fileName options:0 range:range];
+
+			if (match) {
+				NSRange sizeRange = [match rangeAtIndex:1];
+				NSString* sizeString = [fileName substringWithRange:sizeRange];
+				NSInteger sizeValue = [sizeString integerValue];
+
+				if ((bestMatchFileName == nil) || ((sizeValue > bestMatchSizeValue) && (sizeValue <= maximumSizeValue))) {
+					bestMatchFileName = fileName;
+					bestMatchSizeValue = sizeValue;
+				}
 			}
 		}
+
+		if (bestMatchFileName == nil) {
+			return nil;
+		}
+		
+		bestMatchFilePath = [absoluteFolderPath stringByAppendingPathComponent:bestMatchFileName];
 	}
 
-	if (bestMatchFileName == nil) {
-		return nil;
-	}
-
-	NSString* bestMatchFilePath = [absoluteFolderPath stringByAppendingPathComponent:bestMatchFileName];
 	NSURL* bestMatchFileURL = [NSURL fileURLWithPath:bestMatchFilePath isDirectory:NO];
 	NSError* dataError = nil;
 	NSData* data = [NSData dataWithContentsOfURL:bestMatchFileURL options:NSDataReadingMappedIfSafe error:&dataError];
@@ -701,7 +814,6 @@
 
 	return data;
 }
-
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/IMBLightroomObject.h
+++ b/IMBLightroomObject.h
@@ -67,11 +67,13 @@
 @interface IMBLightroomObject : IMBObject
 {
 	NSString* _absolutePyramidPath;
+	NSString* _resolvedPyramidPath;
 	NSNumber* _idLocal;
 	BOOL _isLoadingQuicklookPreview;
 }
 
 @property (retain) NSString* absolutePyramidPath;
+@property (retain) NSString* resolvedPyramidPath;
 @property (retain) NSNumber* idLocal;
 
 @end

--- a/IMBLightroomObject.m
+++ b/IMBLightroomObject.m
@@ -67,6 +67,7 @@
 @implementation IMBLightroomObject
 
 @synthesize absolutePyramidPath = _absolutePyramidPath;
+@synthesize resolvedPyramidPath = _resolvedPyramidPath;
 @synthesize idLocal = _idLocal;
 
 
@@ -78,6 +79,7 @@
 	if ((self = [super init]))
 	{
 		_absolutePyramidPath = nil;
+		_resolvedPyramidPath = nil;
 	}
 	
 	return self;
@@ -87,6 +89,7 @@
 - (void) dealloc
 {
 	IMBRelease(_absolutePyramidPath);
+	IMBRelease(_resolvedPyramidPath);
 	IMBRelease(_idLocal);
 	[super dealloc];
 }
@@ -100,6 +103,7 @@
 	if ((self = [super initWithCoder:inCoder]) != nil)
 	{
 		self.absolutePyramidPath = [inCoder decodeObjectForKey:@"absolutePyramidPath"];
+		self.resolvedPyramidPath = [inCoder decodeObjectForKey:@"resolvedPyramidPath"];
 		self.idLocal = [inCoder decodeObjectForKey:@"idLocal"];
 	}
 	
@@ -112,6 +116,7 @@
 	[super encodeWithCoder:inCoder];
 	
 	[inCoder encodeObject:self.absolutePyramidPath forKey:@"absolutePyramidPath"];
+	[inCoder encodeObject:self.resolvedPyramidPath forKey:@"resolvedPyramidPath"];
 	[inCoder encodeObject:self.idLocal forKey:@"idLocal"];
 }
 
@@ -123,6 +128,7 @@
 {
 	IMBLightroomObject* copy = [super copyWithZone:inZone];
 	copy.absolutePyramidPath = self.absolutePyramidPath;
+	copy.resolvedPyramidPath = self.resolvedPyramidPath;
 	copy.idLocal = self.idLocal;
 	return copy;
 }

--- a/IMBLightroomParser.h
+++ b/IMBLightroomParser.h
@@ -105,6 +105,7 @@ IMBLightroomNodeType;
 + (NSString*) lightroomAppVersion;
 + (NSString*) lightroomAppBundleIdentifier;
 
+- (BOOL)usesLrprevPyramidFiles;
 
 // Return an array to Lightroom library files...
 + (NSArray*) libraryPaths;

--- a/IMBLightroomParser.m
+++ b/IMBLightroomParser.m
@@ -53,6 +53,7 @@
 #pragma mark HEADERS
 
 #import "IMBLightroomParser.h"
+#import "IMBLightroomModernParser.h"
 #import "IMBLightroomObject.h"
 #import "FMDatabase.h"
 #import "FMDatabasePool.h"
@@ -222,6 +223,11 @@ static NSArray* sSupportedImageUTIs = nil;
 {
 	[self imb_throwAbstractBaseClassExceptionForSelector:_cmd];
 	return nil;
+}
+
+- (BOOL)usesLrprevPyramidFiles
+{
+	return NO;
 }
 
 // Key in Ligthroom app user defaults: which library to load
@@ -1544,11 +1550,38 @@ static NSArray* sSupportedImageUTIs = nil;
 - (IMBResourceAccessibility) accessibilityForObject:(IMBObject*)inObject
 {
     IMBResourceAccessibility accessibility = kIMBResourceDoesNotExist;
-	
-    NSString* path = [self.mediaType isEqualToString:kIMBMediaTypeImage] ?
-		((IMBLightroomObject*)inObject).absolutePyramidPath :
-		inObject.location.path;
-    
+	NSString* path = nil;
+
+	if ([self.mediaType isEqualToString:kIMBMediaTypeImage])
+	{
+		IMBLightroomObject* lightroomObject = (IMBLightroomObject*)inObject;
+		NSString* absolutePyramidPath = lightroomObject.absolutePyramidPath;
+		NSString* resolvedPyramidPath = lightroomObject.resolvedPyramidPath;
+
+		if (resolvedPyramidPath == nil)
+		{
+			BOOL usesLrprevPyramidFiles = [self usesLrprevPyramidFiles];
+
+			if ((! usesLrprevPyramidFiles) && (absolutePyramidPath != nil))
+			{
+				resolvedPyramidPath = [IMBLightroomModernParser resolvedPyramidPathWithPyramidPath:absolutePyramidPath preferLrprev:NO acceptAlternateDigest:NO];
+			}
+
+			if (resolvedPyramidPath == nil)
+			{
+				resolvedPyramidPath = absolutePyramidPath;
+			}
+
+			lightroomObject.resolvedPyramidPath = resolvedPyramidPath;
+		}
+
+		path = resolvedPyramidPath;
+	}
+	else
+	{
+		path = inObject.location.path;
+	}
+
     if (path)
 	{
         accessibility = [[NSURL fileURLWithPath:path] imb_accessibility];


### PR DESCRIPTION
Starting with Lightroom 13.3, Lightroom no longer uses .lrprev files to store preview pyramids. Previews at various sizes are now stored as JPEG files with no extension. These files are stored in the same location where the .lrprev were previously stored. The JPEG files share the same file name as the .lrprev, lack the file extension, and have a suffix specifying the preview size.